### PR TITLE
feat: 구독한 브랜드 리스트 화면 구현 및 헤더 UI 정렬 개선

### DIFF
--- a/navigation/MainStack.tsx
+++ b/navigation/MainStack.tsx
@@ -12,6 +12,7 @@ import BrandMenuListScreen from '../screens/BrandMenuListScreen';
 import ReviewWriteScreen from '../screens/ReviewWriteScreen';
 import ReviewListScreen from '../screens/ReviewListScreen';
 import MyReviewListScreen from '../screens/MyReviewListScreen';
+import SubscribedBrandListScreen from '../screens/SubscribedBrandListScreen';
 /*이름(name)과 컴포넌트(component)를 연결해서 
 /*앱에서 화면 간 이동이 가능하게 만들어주는 파일 */
 /* Login = LoginSceen 이라 등록해놓으면 navigate할때 Login이라고만 명시해도됨! */
@@ -29,6 +30,7 @@ export type RootStackParamList = {
   SearchResult: {results: any[]};
   MyReviewList: undefined;
   Home: undefined;
+  SubscribedBrandList: undefined;
 
   //SearchResult: {results: any};
   ReviewWrite: {
@@ -75,6 +77,11 @@ const MainStack = () => {
           name="MyReviewList"
           component={MyReviewListScreen}
           options={{title: '내 리뷰'}}
+        />
+        <Stack.Screen
+          name="SubscribedBrandList"
+          component={SubscribedBrandListScreen}
+          options={{headerShown: false}}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/screens/MyPageScreen.tsx
+++ b/screens/MyPageScreen.tsx
@@ -48,7 +48,9 @@ const MyPage = () => {
 
         <View style={styles.separator} />
         <View style={styles.iconRow}>
-          <TouchableOpacity style={styles.iconButton}>
+          <TouchableOpacity
+            style={styles.iconButton}
+            onPress={() => navigation.navigate('SubscribedBrandList')}>
             <MaterialIcons name="subscriptions" size={30} color="#3366ff" />
             <Text style={styles.iconLabel}>브랜드 구독</Text>
           </TouchableOpacity>

--- a/screens/SubscribedBrandListScreen.tsx
+++ b/screens/SubscribedBrandListScreen.tsx
@@ -1,0 +1,117 @@
+// screens/SubscribedBrandListScreen.tsx
+import React, {useEffect, useState, useContext} from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  Dimensions,
+} from 'react-native';
+import {useNavigation} from '@react-navigation/native';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {RootStackParamList} from '../navigation/MainStack';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {API_URL} from '@env';
+import {AuthContext} from '../contexts/AuthContext';
+import {Ionicons} from '@expo/vector-icons';
+
+const {width} = Dimensions.get('window');
+type Navigation = NativeStackNavigationProp<RootStackParamList>;
+
+const SubscribedBrandListScreen = () => {
+  const navigation = useNavigation<Navigation>();
+  const [brands, setBrands] = useState<any[]>([]);
+  const {user} = useContext(AuthContext);
+
+  useEffect(() => {
+    const fetchSubscribedBrands = async () => {
+      try {
+        const res = await fetch(
+          `${API_URL}/api/subscribe/list?userId=${user.userId}`,
+        );
+        const data = await res.json();
+        setBrands(data);
+      } catch (error) {
+        console.error('구독 브랜드 목록 불러오기 실패:', error);
+      }
+    };
+
+    fetchSubscribedBrands();
+  }, []);
+
+  const handleBrandPress = (brand: any) => {
+    navigation.navigate('BrandMenuList', {
+      brandName: brand.brandName,
+      businessId: brand.businessId,
+    });
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.headerRow}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          style={styles.backButton}>
+          <Ionicons name="arrow-back" size={24} color="black" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>⭐ 구독한 브랜드</Text>
+      </View>
+
+      <FlatList
+        data={brands}
+        keyExtractor={(item, index) => item.businessId.toString()}
+        renderItem={({item}) => (
+          <TouchableOpacity
+            style={styles.brandItem}
+            onPress={() => handleBrandPress(item)}>
+            <Text style={styles.brandText}>{item.brandName}</Text>
+          </TouchableOpacity>
+        )}
+        ListEmptyComponent={
+          <Text style={styles.empty}>구독한 브랜드가 없습니다.</Text>
+        }
+      />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    backgroundColor: '#fff',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+    position: 'relative',
+  },
+  backButton: {
+    position: 'absolute',
+    left: 0,
+    padding: 4,
+  },
+  headerTitle: {
+    fontSize: 22,
+    fontWeight: 'bold',
+  },
+  brandItem: {
+    padding: 16,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+  brandText: {
+    fontSize: 16,
+  },
+  empty: {
+    textAlign: 'center',
+    color: '#999',
+    marginTop: 50,
+  },
+});
+
+export default SubscribedBrandListScreen;


### PR DESCRIPTION
- 구독한 브랜드 리스트 화면 구현 및 API 연동
- 브랜드 선택 시 해당 메뉴 리스트 화면으로 이동 기능 추가
- 상단에 뒤로가기 버튼 추가
- 구독한 브랜드 텍스트를 정확히 화면 중앙에 오도록 정렬 구조 개선
- 전체 레이아웃 padding/margin 등 UI 스타일 정리