### PR TITLE
feat: 메인페이지 로그인/로그아웃 버튼 제거 및 마이페이지로 기능 이동

### DIFF
--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,12 +1,5 @@
-import React, {useState, useContext} from 'react';
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  StyleSheet,
-  Dimensions,
-} from 'react-native';
-import {Alert} from 'react-native';
+import React, {useState} from 'react';
+import {View, StyleSheet, Dimensions} from 'react-native';
 import SearchBar from '../components/mainpage/SearchBar';
 import Banner from '../components/mainpage/Banner';
 import CategoryTabs from '../components/mainpage/CategoryTabs';
@@ -15,7 +8,6 @@ import {API_URL} from '@env';
 import {useNavigation} from '@react-navigation/native';
 import {RootStackParamList} from '../types/navigation';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
-import {AuthContext} from '../contexts/AuthContext';
 import LocalMenuAlert from '../components/local_menu/LocalMenuAlert';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -25,42 +17,17 @@ const {height} = Dimensions.get('window');
 const HomeScreen = () => {
   const [selectedCategory, setSelectedCategory] =
     useState<string>('defaultCategory');
-  const navigation = useNavigation(); // ✅ 페이지 이동용 navigation
-  const {user, logout} = useContext(AuthContext); // ✅ 로그인 상태와 로그아웃 기능을 AuthContext에서 받아옴
-  const [alertModalVisible, setAlertModalVisible] = useState(true); //지역 메뉴 알림창 모델 관련 상태 변수
+  const navigation = useNavigation();
+  const [alertModalVisible, setAlertModalVisible] = useState(true);
 
-  // ✅ 로그아웃 버튼 눌렀을때 실행되는 함수
-  const handleLogout = () => {
-    Alert.alert(
-      '로그아웃',
-      '정말 로그아웃 하시겠습니까?',
-      [
-        {
-          text: '취소',
-          style: 'cancel',
-        },
-        {
-          text: '로그아웃',
-          onPress: () => {
-            logout(); // user = null
-          },
-          style: 'destructive',
-        },
-      ],
-      {cancelable: true},
-    );
-  };
-
-  // ✅ 검색창에서 키워드 검색 시 실행되는 함수
   const handleSearch = async (keyword: string) => {
     try {
       const response = await fetch(
         `${API_URL}/menu/search?keyword=${encodeURIComponent(keyword)}`,
       );
       const data = await response.json();
-      // console.log('받아온 메뉴 데이터:', data);
       //@ts-ignore
-      navigation.navigate('SearchResult', {results: data}); // ✅ 검색결과 페이지로 이동
+      navigation.navigate('SearchResult', {results: data});
     } catch (error) {
       console.error('검색 중 오류 발생:', error);
     }
@@ -76,28 +43,6 @@ const HomeScreen = () => {
         onNeverShow={() => setAlertModalVisible(false)}
       />
 
-      {/* ✅ 로그인/로그아웃 버튼 - 검색창 위 오른쪽 정렬 */}
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'flex-end',
-          paddingHorizontal: 16,
-          marginTop: 16,
-        }}>
-        {user ? ( // ✅ 로그인이 되어 있을 경우
-          <TouchableOpacity style={styles.loginButton} onPress={handleLogout}>
-            <Text style={styles.loginButtonText}>Logout</Text>
-          </TouchableOpacity>
-        ) : (
-          // ✅ 로그인이 안되어 있을 경우
-          <TouchableOpacity
-            style={styles.loginButton}
-            onPress={() => navigation.navigate('Login')}>
-            <Text style={styles.loginButtonText}>Login</Text>
-          </TouchableOpacity>
-        )}
-      </View>
-
       {/* ✅ 검색 기능 연결 */}
       <SearchBar onSearch={handleSearch} />
 
@@ -107,14 +52,13 @@ const HomeScreen = () => {
         setSelectedCategory={setSelectedCategory}
       />
     </View>
-    // </ScrollView>
   );
 };
 
 const styles = StyleSheet.create({
   loginButton: {
     backgroundColor: '#8000FF',
-    paddingVertical: 8, //height * 0.01
+    paddingVertical: 8,
     paddingHorizontal: 16,
     borderRadius: 20,
   },

--- a/screens/MyPageScreen.tsx
+++ b/screens/MyPageScreen.tsx
@@ -1,10 +1,11 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useState, useContext} from 'react';
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
   ScrollView,
+  Alert,
 } from 'react-native';
 import {getStoredUserData} from '../services/auth';
 import {UserData} from '../types/UserData';
@@ -13,23 +14,51 @@ import {
   MaterialIcons,
   MaterialCommunityIcons,
 } from '@expo/vector-icons';
-import {useNavigation} from '@react-navigation/native';
+import {useNavigation, useFocusEffect} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {RootStackParamList} from '../navigation/MainStack';
+import {AuthContext} from '../contexts/AuthContext';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const MyPage = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const [userData, setUserData] = useState<UserData | null>(null);
+  const {user, logout} = useContext(AuthContext);
 
-  useEffect(() => {
-    const loadUserData = async () => {
-      const data = await getStoredUserData();
-      setUserData(data);
-    };
-    loadUserData();
-  }, []);
+  useFocusEffect(
+    React.useCallback(() => {
+      const loadUserData = async () => {
+        const data = await getStoredUserData();
+        setUserData(data);
+      };
+      loadUserData();
+    }, []),
+  );
+
+  const handleLogout = () => {
+    Alert.alert(
+      '로그아웃',
+      '정말 로그아웃 하시겠습니까?',
+      [
+        {text: '취소', style: 'cancel'},
+        {
+          text: '로그아웃',
+          style: 'destructive',
+          onPress: async () => {
+            await AsyncStorage.removeItem('userData');
+            logout();
+            navigation.reset({
+              index: 0,
+              routes: [{name: 'Main'}],
+            });
+          },
+        },
+      ],
+      {cancelable: true},
+    );
+  };
 
   return (
     <View style={styles.screenWrapper}>
@@ -86,10 +115,20 @@ const MyPage = () => {
 
       {/* 고정 하단 버튼 */}
       <View style={styles.buttonGroup}>
-        <TouchableOpacity style={styles.actionButton}>
-          <Text style={styles.actionButtonText}>로그아웃</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.actionButton}>
+        {user ? (
+          <TouchableOpacity style={styles.actionButton} onPress={handleLogout}>
+            <Text style={styles.actionButtonText}>로그아웃</Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            style={styles.actionButton}
+            onPress={() => navigation.navigate('Login')}>
+            <Text style={styles.actionButtonText}>로그인</Text>
+          </TouchableOpacity>
+        )}
+        <TouchableOpacity
+          style={styles.actionButton}
+          onPress={() => navigation.navigate('UserEdit')}>
           <Text style={styles.actionButtonText}>내정보 수정</Text>
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
- HomeScreen에서 로그인/로그아웃 버튼 UI 제거
- MyPage에서 로그인 상태에 따라 로그인/로그아웃 버튼 분기 처리
- 로그인하지 않은 경우 로그인 버튼 노출 및 로그인 화면으로 이동
- 로그아웃 시 AsyncStorage 초기화 및 메인화면으로 리셋 이동 처리